### PR TITLE
Handle mode logic and rendering tiles implemented, but not tested

### DIFF
--- a/core/ppu.cpp
+++ b/core/ppu.cpp
@@ -8,11 +8,19 @@
 //   this->mmu = mmu;
 //   mode = OAM;
 //   cyclesLeft = 0;
+
+//   frameBuffer = new u8**[LCD_HEIGHT];
+//   for (int i=0; i<LCD_HEIGHT; i++) {
+//     frameBuffer[i] = new u8*[LCD_WIDTH];
+//     for (int j=0; j<LCD_WIDTH; j++) {
+//       frameBuffer[i][j] = new u8[3];
+//     }
+//   }
 // }
 
 // LCDC (0xFF40) - LCD Control
   // (see lcdc helper functions)
-u16 PPU::get_lcdc() { return mmu.read(0xFF40); }
+u8 PPU::get_lcdc() { return mmu.read(LCDC); }
 // STAT (0xFF41) - LCD Status
   // Bit 6 - LYC=LY STAT Interrupt source         (1=Enable) (Read/Write)
   // Bit 5 - Mode 2 OAM STAT Interrupt source     (1=Enable) (Read/Write)
@@ -24,37 +32,39 @@ u16 PPU::get_lcdc() { return mmu.read(0xFF40); }
   //           1: VBlank
   //           2: Searching OAM
   //           3: Transferring Data to LCD Controller
-u16 PPU::get_stat() { return mmu.read(0xFF41); }
+u8 PPU::get_stat() { return mmu.read(STAT); }
 // ScrollY (0xFF42) - y pos of background
-u16 PPU::get_scy() { return mmu.read(0xFF42); }
+u8 PPU::get_scy() { return mmu.read(SCY); }
 // ScrollX (0xFF43) - x pos of background
-u16 PPU::get_scx() { return mmu.read(0xFF43); }
+u8 PPU::get_scx() { return mmu.read(SCX); }
 // LY (0xFF44) - LCD Y Coordinate (aka current scanline)
 // Holds values 0-153, with 144-153 indicating VBLANK
-u16 PPU::get_ly() { return mmu.read(0xFF44); }
+u8 PPU::get_ly() { return mmu.read(LY); }
 // LYC (0xFF45) - LY Compare
-u16 PPU::get_lyc() { return mmu.read(0xFF45); }
+u8 PPU::get_lyc() { return mmu.read(LYC); }
 // DMA (0xFF46) - DMA Transfer and Start (160 cycles?)
-u16 PPU::get_dma() { return mmu.read(0xFF46); }
+u8 PPU::get_dma() { return mmu.read(DMA); }
 // bgp (0xFF47) - BG palette data
   // Bit 7-6 Color for index 3
   // Bit 5-4 Color for index 2
   // Bit 3-2 Color for index 1
   // Bit 1-0 Color for index 0
-u16 PPU::get_bgp() { return mmu.read(0xFF47); }
+u8 PPU::get_bgp() { return mmu.read(BGP); }
 // obp0 (0xFF48) - OBJ palette 0 dataQ
 // Just like bgp but bits 1-0 ignored because color index 0 is transparent for sprites
-u16 PPU::get_obp0() { return mmu.read(0xFF48); }
+u8 PPU::get_obp0() { return mmu.read(OBP0); }
 // obp1 (0XFF49) - OBJ palette 1 data
-u16 PPU::get_obp1() { return mmu.read(0xFF49); }
+u8 PPU::get_obp1() { return mmu.read(OBP1); }
 
-u16 PPU::get_wy() { return mmu.read(0xFF4A); }
-u16 PPU::get_wx() { return mmu.read(0xFF4B); }
+u8 PPU::get_wy() { return mmu.read(WY); }
+u8 PPU::get_wx() { return mmu.read(WX); }
 
-u8* PPU::getFrameBuffer() { return frameBuffer; }
+u8*** PPU::getFrameBuffer() { 
+  return frameBuffer;
+}
 
 // Define setters as needed
-
+void PPU::set_ly(u8 ly) { mmu.write(LY, ly); }
 
 // lcdc register helper functions 
 // Bit 7	LCD and PPU enable	0=Off, 1=On
@@ -76,6 +86,8 @@ bool PPU::isBgWinEnabled() { return checkBit(get_lcdc(), 0); }
 
 void PPU::step(u8 cpuCyclesElapsed) {
 
+  if (!isLCDEnabled()) { return; }
+
   cyclesLeft += cpuCyclesElapsed / 2; // is this corect behavior or should remaining cycles not carry over?
 
   // switch based on current mode
@@ -88,29 +100,103 @@ void PPU::step(u8 cpuCyclesElapsed) {
   switch(mode) {
     case OAM:
       if (cyclesLeft >= OAM_CLOCKS) {
-
+        cyclesLeft -= OAM_CLOCKS;
+        
+        // update stat register for VRAM mode
+        u8 stat = get_stat();
+        stat = setBit(stat, 0);
+        stat = setBit(stat, 1);
+        mmu.write(STAT, stat);
+        mode = VRAM;
       }
       break;
     case VRAM:
-      if (cyclesLeft >= VRAM_CLCOKS) {
+      if (cyclesLeft >= VRAM_CLOCKS) {
+        cyclesLeft -= VRAM_CLOCKS;
 
+        drawScanLine();
+        
+        mode = HBLANK;
+        u8 stat = get_stat();
+        stat = clearBit(stat, 0);
+        stat = clearBit(stat, 1);
+        mmu.write(STAT, stat);
+
+        // check for HBLANK interrupt
+        if (checkBit(get_stat(), 3)) {
+          // signal cpu interrupt?
+        }
       }
       break;
     case HBLANK:
       if (cyclesLeft >= HBLANK_CLOCKS) {
+        cyclesLeft -= HBLANK_CLOCKS;
 
+        u8 scanline = get_ly();
+
+        // check lyc interupt // should this be somewhere else?
+        bool lyc = (scanline == get_lyc());
+        if (checkBit(get_stat(), 6) && lyc) {
+          // signal cpu interrupt?
+        }
+        
+        // increment current line
+        scanline++;
+        mmu.write(LY, scanline);
+
+        // check current scanline == 144, then enter VBLANK, else enter OAM to prepare to draw another line
+        if (scanline == 144) {
+          mode = VBLANK;
+          u8 stat = get_stat();
+          stat = lyc ? setBit(stat, 2) : clearBit(stat, 2);
+          stat = setBit(stat, 0);
+          stat = clearBit(stat, 1);
+          mmu.write(STAT, stat);
+
+          if (checkBit(get_stat(), 4)) {
+            // signal cpu interrupt?
+          }
+        } else {
+          mode = OAM;
+          u8 stat = get_stat();
+          stat = lyc ? setBit(stat, 2) : clearBit(stat, 2);
+          stat = clearBit(stat, 0);
+          stat = setBit(stat, 1);
+          mmu.write(STAT, stat);
+
+          if (checkBit(get_stat(), 5)) {
+            // signal cpu interrupt?
+          }
+        }
       }
       break;
     case VBLANK:
       if (cyclesLeft >= VBLANK_CLOCKS) {
+        cyclesLeft -= VBLANK_CLOCKS;
 
+        // increment current line
+        u8 scanline = get_ly() + 1;
+        mmu.write(LY, scanline);
+
+        // reset scanline to 0 if > 153 (end of VBLANK)
+        if (scanline == 154) {
+
+          // reset scanline to 0
+          mmu.write(LY, 0);
+          
+          mode = OAM;
+          u8 stat = get_stat();
+          stat = clearBit(stat, 0);
+          stat = setBit(stat, 1);
+          mmu.write(STAT, stat);
+
+          if (checkBit(get_stat(), 5)) {
+            // signal cpu interrupt?
+          }
+        }
       }
       break;
   }
-
-  // check current scanline == 144, then enter VBLANK
-  // reset scanline to 0 if > 153 (end of VBLANK)
-  // when less than 144, call drawScanLine(lcd_ctrl)
 }
 
 // PPU mode typically goes from OAM -> VRAM -> HBLANK, repeating until VBLANK (aka mode 1)
@@ -120,8 +206,7 @@ void PPU::step(u8 cpuCyclesElapsed) {
   // HBLANK - 87-204 clocks (22-51) cycles) (depending on prev) [set default to start at 289?]
 void PPU::drawScanLine() {
 
-  if (!isLCDEnabled()) { return; }
-
+  // Should rednering background and window be done separately for simplicity sake?
   if (isBgWinEnabled()) {
     renderTiles();
   }
@@ -145,22 +230,99 @@ void PPU::renderTiles() {
 
   // LCDC Bit 4	BG and Window tile data area	0=8800-97FF, 1=8000-8FFF
   u16 tileData = tileDataArea();
+  bool unsig = checkBit(get_lcdc(), 4);
 
-  // LCDC Bit 3	BG tile map area	0=9800-9BFF, 1=9C00-9FFF
-  u16 bgMap = bgTileMapArea();
-
-  // LCDC Bit 5	Window enable	0=Off, 1=On
-  // Check if window's Y position is within the current scanline
-  // LCDC Bit 6	Window tile map area	0=9800-9BFF, 1=9C00-9FFF
-  u16 winMap;
-  if (isWindowEnabled() && get_wy() <= get_ly()) {
-    winMap = windowTileMapArea();
+  // Check if window's Y position is within the current scanline and window is enabled
+  // Tetris doesn't use a window, so this should be just set to the bgTileMapAreaa()
+  u16 tileMap;
+  bool winEnabled = (isWindowEnabled() && get_wy() <= get_ly());
+  if (!winEnabled) {
+    tileMap = bgTileMapArea();
+  } else {
+    tileMap = windowTileMapArea();
   }
+
+  u8 currentLine = get_ly();
+
+  // calculate current row of tiles we are on
+  u8 yPos = 0;
+  if (!winEnabled) {
+    yPos = scrollY + currentLine;
+  } else {
+    yPos = currentLine - windowY;
+  }
+
+  // calculate which row of pixels in the above tile we are on (32 tiles vertical, 8 pixels per tile)
+  u16 currPixelRow = ((u8)(yPos/8)*32);
 
   // draw current line of pixels
-  for (int i = 0; i < LCD_HEIGHT; i++) {
+  for (int i = 0; i < LCD_WIDTH; i++) {
+    u8 xPos = i + scrollX;
 
+    // same as above for x offset (if window is enabled)
+    if (winEnabled) {
+      if (i >= windowX) {
+        xPos = i - windowX;
+      }
+    }
+    
+    u16 currPixelCol = (xPos/8);
+    u16 tileAddress = tileMap + currPixelRow + currPixelCol;
+
+    s16 tileNum;
+    if (unsig) {
+      tileNum = (u8)mmu.read(tileAddress);
+    } else {
+      tileNum = (s8)mmu.read(tileAddress);
+    }
+
+    // adjust for unsigned by using 128 size offset
+    u16 tileLoc = tileData;
+    if (unsig) {
+      tileLoc += (tileNum * 16);
+    } else {
+      tileLoc += ((tileNum + 128) * 16);
+    }
+
+     u8 line = yPos % 8;
+     line *= 2; // two bytes of mem per line
+     u8 byte1 = mmu.read(tileLoc + line);
+     u8 byte2 = mmu.read(tileLoc + line + 1);
+
+     int colorBit = xPos % 8;
+     colorBit -= 7;
+     colorBit *= -1;
+
+     int colorId = checkBit(byte2, colorBit);
+     colorId <<= 1;
+     colorId |= checkBit(byte1, colorBit);
+
+     int color = getcolor(colorId, BGP) ;
+     
+     u8 red = 0;
+     u8 green = 0;
+     u8 blue = 0;
+     switch(color) {
+       case 0: red = 155; green = 188 ; blue = 15; break;   // WHITE = 0  #9bbc0f RGB: 155, 188, 15
+       case 1:red = 139; green = 172 ; blue = 15; break;    // LIGHT_GRAY = 1 #8bac0f RGB: 139, 172, 15
+       case 2: red = 48; green = 98 ; blue = 48; break;     // DARK_GRAY = 2  #306230 RGB: 48, 98, 48
+       default: red = 15; green = 56; blue = 15; break;     // BLACK = 3  #0f380f RGB: 15, 56, 15
+     }
+
+     frameBuffer[i][currentLine][0] = red ;
+     frameBuffer[i][currentLine][1] = green ;
+     frameBuffer[i][currentLine][2] = blue ;
   }
+}
+
+int PPU::getcolor(int id, u16 palette) {
+    u8 palette = mmu.read(palette);
+    int hi = 2 * id + 1;
+    int lo = 2 * id;
+    int bit1 = (palette >> hi) & 1;
+    int bit0 = (palette >> lo) & 1;
+
+    return (bit1 << 1) | bit0;
 }
 
 // OAM table: 0xFE00 - 0XFE9F
@@ -179,9 +341,10 @@ void PPU::renderTiles() {
     // Bit 2-0 Palette number  **CGB Mode Only**     (OBP0-7)
 void PPU::renderSprites() {
 
-  bool use8x16 = isObj8x16();
+  return; // TODO: implement this
 
-  // ...
+  bool use8x16 = isObj8x16();
+  int objSize = use8x16 ? 16 : 8;
 
   // can render up to 40 sprites, iterate through OAM table
   for (int i = 0; i < 40; i++) {
@@ -191,6 +354,18 @@ void PPU::renderSprites() {
     u8 tileIndex = mmu.read(OAM_TABLE + spriteIndex + 2);
     u8 attr = mmu.read(OAM_TABLE + spriteIndex + 3);
 
-    // check attributes?
+    // check sprite attributes
+    const bool bgOverObj = checkBit(attr, 7);
+    const bool yFlip = checkBit(attr, 6);
+    const bool xFlip = checkBit(attr, 5);
+    const u16 pallete = checkBit(attr, 4) ? OBP1 : OBP0;
+
+    // get current scanline
+    u8 scanline = get_ly();
+
+    // draw row of pixels in sprite if sprite intercepts scanline
+    if (scanline >= yPos && scanline < (yPos + objSize)) {
+
+    }
   }
 }

--- a/core/ppu.hpp
+++ b/core/ppu.hpp
@@ -26,24 +26,26 @@ public:
 
   // This is pulled out into a method, instead of public field access, so you only
   // have to update the buffer when SDL asks for it
-  u8* getFrameBuffer();
-
-  CPU getCPU();
-  MMU getMMU();
+  u8*** getFrameBuffer();
 
   // Register getters
-  u16 get_lcdc();
-  u16 get_stat();
-  u16 get_scy();
-  u16 get_scx();
-  u16 get_ly();
-  u16 get_lyc();
-  u16 get_dma();
-  u16 get_bgp();
-  u16 get_obp0();
-  u16 get_obp1();
-  u16 get_wy();
-  u16 get_wx();
+  u8 get_lcdc();
+  u8 get_stat();
+  u8 get_scy();
+  u8 get_scx();
+  u8 get_ly();
+  u8 get_lyc();
+  u8 get_dma();
+  u8 get_bgp();
+  u8 get_obp0();
+  u8 get_obp1();
+  u8 get_wy();
+  u8 get_wx();
+
+  // Register setters
+  void set_ly(u8 ly);
+
+  int getcolor(int id, u16 palette);
     
 private:
   CPU cpu;
@@ -55,16 +57,24 @@ private:
   const int LCD_HEIGHT = 160;
 
   const int OAM_CLOCKS = 80;
-  const int VRAM_CLCOKS = 172;
+  const int VRAM_CLOCKS = 172;
   const int HBLANK_CLOCKS = 204;
   const int VBLANK_CLOCKS = 4560;
 
   const u16 OAM_TABLE = 0xFE00;
 
-  // WHITE = 0  #9bbc0f RGB: 155, 188, 15
-  // LIGHT_GRAY = 1 #8bac0f RGB: 139, 172, 15
-  // DARK_GRAY = 2  #306230 RGB: 48, 98, 48
-  // BLACK = 3  #0f380f RGB: 15, 56, 15
+  const u16 LCDC = 0xFF40;
+  const u16 STAT = 0xFF41;
+  const u16 SCY = 0xFF42;
+  const u16 SCX = 0xFF43;
+  const u16 LY = 0xFF44;
+  const u16 LYC = 0xFF45;
+  const u16 DMA = 0xFF46;
+  const u16 BGP = 0xFF47;
+  const u16 OBP0 = 0xFF48;
+  const u16 OBP1 = 0xFF49;
+  const u16 WY = 0xFF4A;
+  const u16 WX = 0xFF4B;
 
   // 'lcdc' register helper functions
   bool isLCDEnabled();
@@ -82,7 +92,7 @@ private:
   void renderSprites();
 
   // 160 x 144 x 3 (last dimenstion is pixel, rgb)
-  static u8* frameBuffer;
+  static u8*** frameBuffer;
 
   // 256 x 256
   u8* backgroundMap;

--- a/core/ppu.hpp
+++ b/core/ppu.hpp
@@ -26,7 +26,7 @@ public:
 
   // This is pulled out into a method, instead of public field access, so you only
   // have to update the buffer when SDL asks for it
-  u8*** getFrameBuffer();
+  u8* getFrameBuffer();
 
   // Register getters
   u8 get_lcdc();
@@ -44,6 +44,8 @@ public:
 
   // Register setters
   void set_ly(u8 ly);
+  
+  void checkLYC(u8 scanline);
 
   int getcolor(int id, u16 palette);
     
@@ -92,7 +94,7 @@ private:
   void renderSprites();
 
   // 160 x 144 x 3 (last dimenstion is pixel, rgb)
-  static u8*** frameBuffer;
+  static u8* frameBuffer;
 
   // 256 x 256
   u8* backgroundMap;


### PR DESCRIPTION
Notes:
- I was having trouble with handling a 3-dimensional frame buffer, maybe someone who is better at c++ than me could provide help on this. The only way I got it working was with a triple pointer, and initializing the buffer as seen in the constructor (currently commented out for first comment under 'For CPU:')
- I have not tested anything yet (kind of hard to until all the other pieces are in place), but I think the core logic should be implemented for switching based on modes and rendering tiles (both background and window). I don't believe Tetris uses a window so that should simplify things. Sprites aren't implemented yet but if all else fails, that can wait until after the first demo. There are probably lots of bugs I still need to fix once subsystems + SDL are working.

For CPU:

- Need a default constructor? The PPU's constructor is complaining at me because their isn't one
- Need to handle interrupts? I have a few spots in the code where an interrupt bit is checked, and if it is set 
(presumably by the CPU), the PPU needs to signal an interrupt for the CPU to handle. I don't know how crucial this is for Tetris or if it is even needed, but something doesn't seem like it would be too hard to hook up. Let me know if my understanding on this is correct.

For MMU:

- Needs to restrict access for CPU reads/writes when the PPU is in certain modes, as follows:
  During mode `OAM`: CPU cannot access OAM (0xFE00 - 0xFE9F)
  During mode `VRAM`: CPU cannot access VRAM (0x8000-0x97FF) or OAM (0xFE00 - 0xFE9F)
  During restricted modes, any attempt to read returns 0xFF, any attempt to write are ignored

For SDL:

- Need to figure out the first point in 'Notes', being how we are going to format the frame buffer, if there is an easier way to pass a pointer to the beginning of a 3d array or if it would be easier to flatten it, etc. 