### PR TITLE
Remove cross-platform incompatible std::filesystem library

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,1 @@
-g++ -std=c++17 main.cpp -lSDL2main -lSDL2 -o gb-emulator
+g++ -Wall -std=c++17 main.cpp -lSDL2main -lSDL2 -o gb-emulator

--- a/main.cpp
+++ b/main.cpp
@@ -1,4 +1,3 @@
-#include <filesystem>
 #include <fstream>
 #include <iostream>
 
@@ -177,6 +176,9 @@ int main(int argc, char *argv[]) {
 							SDL_Event event = { .type = SDL_QUIT };
 							SDL_PushEvent(&event);
 						} break;
+
+						default: {
+						} break;
 					}
 				} break;
 
@@ -217,12 +219,18 @@ int main(int argc, char *argv[]) {
 						case SDL_SCANCODE_RETURN:
 						case SDL_SCANCODE_H: {
 						} break;
+
+						default: {
+						} break;
 					}
 				} break;
 
 				case SDL_QUIT: {
 					quit = true;
 				} break;
+
+				default: {
+				};
 			}
 		}
 

--- a/main.cpp
+++ b/main.cpp
@@ -73,11 +73,11 @@ int main(int argc, char *argv[]) {
 	char *boot_rom_filename = argv[1];
 	char *game_rom_filename = argv[2];
 
-	int boot_rom_size = load_binary_file(boot_rom_filename, &boot_rom);
+	load_binary_file(boot_rom_filename, &boot_rom);
 
 	atexit(free_boot_rom);
 
-	int game_rom_size = load_binary_file(game_rom_filename, &game_rom);
+	load_binary_file(game_rom_filename, &game_rom);
 
 	atexit(free_game_rom);
 


### PR DESCRIPTION
Due to std::filesystem not playing nice with MinGW, replaced with std::istream.tellg() instead.