### PR TITLE
Implemented Memory Banking

### DIFF
--- a/core/cartridge.cpp
+++ b/core/cartridge.cpp
@@ -4,24 +4,22 @@
 MBCType getMBCType(u8 code) {
   switch (code) {
     case 0x00:
-      return NONE;
+      return NO_MBC;
     case 0x01: case 0x02: case 0x03:
-      return MBC1;
+      return MBC_1;
     case 0x05: case 0x06:
-      return MBC2;
+      return MBC_2;
     case 0x0F: case 0x10: case 0x11: case 0x12: case 0x13:
-      return MBC3;
+      return MBC_3;
     case 0x19: case 0x1A: case 0x1B: case 0x1C: case 0x1D: case 0x1E:
-      return MBC5;
+      return MBC_5;
     default:
       return OTHER;
   }
 }
-
 u32 getRomSize(u8 code) {
   return ROM_BANK_SIZE << code;
 }
-
 u32 getRamSize(u8 code) {
   switch (code) {
     case 0x00: case 0x01: 
@@ -38,10 +36,9 @@ u32 getRamSize(u8 code) {
       return 0;
   }
 }
-
 CartridgeInfo getInfo(u8* rom) {
   CartridgeInfo info = CartridgeInfo();
-  info.title = std::string((char*)rom[TITLE_ADDRESS]);
+  info.title = std::string((char*)(rom + TITLE_ADDRESS));
   info.type = getMBCType(rom[MBC_TYPE_ADDRESS]);
   info.romSize = getRomSize(rom[ROM_SIZE_ADDRESS]);
   info.ramSize = getRamSize(rom[RAM_SIZE_ADDRESS]);
@@ -51,15 +48,20 @@ CartridgeInfo getInfo(u8* rom) {
 Cartridge::Cartridge(u8* rom, CartridgeInfo cartridgeInfo) : rom(rom), cartridgeInfo(cartridgeInfo) {
   ram = cartridgeInfo.ramSize ? new u8[cartridgeInfo.ramSize] : NULL;
 }
+Cartridge::~Cartridge() {}
+u8 Cartridge::read(u16 address) {
+  return rom[address];
+}
+void Cartridge::write(u16 address, u8 value) {
+  //Do nothing
+}
 
 
 
 NoMBC::NoMBC(u8* rom, CartridgeInfo cartridgeInfo) : Cartridge(rom, cartridgeInfo)  {}
-
 u8 NoMBC::read(u16 address) {
   return rom[address];
 }
-
 void NoMBC::write(u16 address, u8 value) {
   //Do nothing
 }
@@ -67,7 +69,6 @@ void NoMBC::write(u16 address, u8 value) {
 
 
 MBC1::MBC1(u8* rom, CartridgeInfo cartridgeInfo) : Cartridge(rom, cartridgeInfo) {}
-
 u8 MBC1::read(u16 address) {
   if (0x0000 <= address && address <= 0x3FFF) {
     return rom[address];
@@ -87,7 +88,6 @@ u8 MBC1::read(u16 address) {
   printf("ERROR :: Attempted cartridge read from illegal address\n");
   return 0x00;
 }
-
 void MBC1::write(u16 address, u8 value) {
   if (0x0000 <= address && address <= 0x1FFF) {
     if (value == 0x00) {
@@ -113,50 +113,74 @@ void MBC1::write(u16 address, u8 value) {
     u16 address_requested = address - 0xA000; //0x0000-0x1FFF
     ram[start_of_ram_bank + address_requested] = value;
   } else {
+    printf("ERROR :: Attempted cartridge write to illegal address\n");
+  }
+}
+
+
+
+MBC3::MBC3(u8* rom, CartridgeInfo cartridgeInfo) : Cartridge(rom, cartridgeInfo) {}
+u8 MBC3::read(u16 address) {
+  if (0x0000 <= address && address <= 0x3FFF) {
+    return rom[address];
+  } else if (0x4000 <= address && address <= 0x7FFF) {
+    u32 start_of_rom_bank = 0x4000 * romBank;
+    u16 address_requested = address - 0x4000; //0x0000-0x3FFF
+    return rom[start_of_rom_bank + address_requested];
+  } else if (0xA000 <= address && address <= 0xBFFF) {
+    if (!ramEnabled) {
+      return 0x00;
+    } else {
+      u32 start_of_ram_bank = 0x2000 * ramBank;
+      u16 address_requested = address - 0xA000; //0x0000-0x1FFF
+      return ram[start_of_ram_bank + address_requested];
+    }
+  } else {
     printf("ERROR :: Attempted cartridge read from illegal address\n");
+    return 0x00;
+  }
+}
+void MBC3::write(u16 address, u8 value) {
+  if (0x0000 <= address && address <= 0x1FFF) {
+    if (value == 0x00) {
+      ramEnabled = false;
+    } else if (getLowNibble(value) == 0xA) {
+      ramEnabled = true;
+    }
+  } else if (0x2000 <= address && address <= 0x3FFF) {
+    romBank = value == 0x00 ? 0x01 : value & 0x7F;
+  } else if (0x4000 <= address && address <= 0x5FFF) {
+    if (value <= 0x03) {
+      ramOverRTC = true;
+      ramBank = value;
+    } else if (0x08 <= value && value <= 0x0C) {
+      ramOverRTC = false;
+      //TODO: Implement clock events.
+      //https://gbdev.io/pandocs/MBC3.html#4000-5fff---ram-bank-number---or---rtc-register-select-write-only
+    }
+  } else if (0x6000 <= address && address <= 0x7FFF) {
+    //TODO: Implement Clock latch
+    // https://gbdev.io/pandocs/MBC3.html#6000-7fff---latch-clock-data-write-only
+  } else if (0xA000 <= address && address <= 0xBFFF) {
+    if (!ramEnabled || !ramOverRTC) { return; }
+
+    u32 start_of_ram_bank = 0x2000 * ramBank;
+    u16 address_requested = address - 0xA000; //0x0000-0x1FFF
+    ram[start_of_ram_bank + address_requested] = value;
   }
 }
 
 
 
 
-
-
-
-
-
-// else if (0x2000 <= address && address <= 0x3FFF) {
-//   romBank = value == 0x00 ? 0x01 : value & 0x7F;
-// } else if (0x4000 <= address && address <= 0x5FFF) {
-//   if (value <= 0x03) {
-//     ram
-//   }
-// }
-
-// class MBC3: public Cartridge {
-// public:
-//   MBC3(u32 gameRomSize);
-
-//   u8 read(u16 address) override;
-//   void write(u16 address, u8 value) override;
-// private:
-//   u8* rom_bank;
-//   u8* ram_bank;
-//   bool ram_enabled = false;
-//   bool ram_over_rtc = true;
-//   bool rom_banking_mode = true;
-// };
-
-
-
 Cartridge* createCartridge(u8* rom, CartridgeInfo cartridgeInfo) {
   switch (cartridgeInfo.type) {
-    case NONE:
-      return new NoMBC::NoMBC(rom, cartridgeInfo);
-    case MBC1: 
-      return new MBC1::MBC1(rom, cartridgeInfo);
-    case MBC3:
-      return new MBC3::MBC3(rom, cartridgeInfo);
+    case NO_MBC:
+      return new NoMBC(rom, cartridgeInfo);
+    case MBC_1: 
+      return new MBC1(rom, cartridgeInfo);
+    case MBC_3:
+      return new MBC3(rom, cartridgeInfo);
     default:
       printf("ERROR :: Cartridge type not currently supported\nERROR :: Program will probably crash\n");
       return new Cartridge(rom, cartridgeInfo);

--- a/core/cartridge.cpp
+++ b/core/cartridge.cpp
@@ -1,11 +1,164 @@
 #include "./cartridge.hpp"
+#include <stdio.h>
 
-Cartridge::Cartridge(u32 gameRomSize) : gameRomSize(gameRomSize) {
-    gameRom = new u8[gameRomSize];
-    bootRom = new u8[BOOT_ROM_SIZE];
+MBCType getMBCType(u8 code) {
+  switch (code) {
+    case 0x00:
+      return NONE;
+    case 0x01: case 0x02: case 0x03:
+      return MBC1;
+    case 0x05: case 0x06:
+      return MBC2;
+    case 0x0F: case 0x10: case 0x11: case 0x12: case 0x13:
+      return MBC3;
+    case 0x19: case 0x1A: case 0x1B: case 0x1C: case 0x1D: case 0x1E:
+      return MBC5;
+    default:
+      return OTHER;
+  }
 }
 
-Cartridge::~Cartridge() {
-    delete[] gameRom;
-    delete[] bootRom;
+u32 getRomSize(u8 code) {
+  return ROM_BANK_SIZE << code;
+}
+
+u32 getRamSize(u8 code) {
+  switch (code) {
+    case 0x00: case 0x01: 
+      return 0;
+    case 0x02:
+      return RAM_BANK_SIZE;
+    case 0x03:
+      return 4 * RAM_BANK_SIZE;
+    case 0x04:
+      return 16 * RAM_BANK_SIZE;
+    case 0x05: 
+      return 8 * RAM_BANK_SIZE;
+    default:
+      return 0;
+  }
+}
+
+CartridgeInfo getInfo(u8* rom) {
+  CartridgeInfo info = CartridgeInfo();
+  info.title = std::string((char*)rom[TITLE_ADDRESS]);
+  info.type = getMBCType(rom[MBC_TYPE_ADDRESS]);
+  info.romSize = getRomSize(rom[ROM_SIZE_ADDRESS]);
+  info.ramSize = getRamSize(rom[RAM_SIZE_ADDRESS]);
+  return info;
+}
+
+Cartridge::Cartridge(u8* rom, CartridgeInfo cartridgeInfo) : rom(rom), cartridgeInfo(cartridgeInfo) {
+  ram = cartridgeInfo.ramSize ? new u8[cartridgeInfo.ramSize] : NULL;
+}
+
+
+
+NoMBC::NoMBC(u8* rom, CartridgeInfo cartridgeInfo) : Cartridge(rom, cartridgeInfo)  {}
+
+u8 NoMBC::read(u16 address) {
+  return rom[address];
+}
+
+void NoMBC::write(u16 address, u8 value) {
+  //Do nothing
+}
+
+
+
+MBC1::MBC1(u8* rom, CartridgeInfo cartridgeInfo) : Cartridge(rom, cartridgeInfo) {}
+
+u8 MBC1::read(u16 address) {
+  if (0x0000 <= address && address <= 0x3FFF) {
+    return rom[address];
+  } else if (0x4000 <= address && address <= 0x7FFF) {
+    u32 start_of_rom_bank = 0x4000 * romBank;
+    u16 address_requested = address - 0x4000; //0x0000-0x3FFF
+    return rom[start_of_rom_bank + address_requested];
+  } else if (0xA000 <= address && address <= 0xBFFF) {
+    if (!ramEnabled) {
+      return 0x00;
+    } else {
+      u32 start_of_ram_bank = 0x2000 * ramBank;
+      u16 address_requested = address - 0xA000; //0x0000-0x1FFF
+      return ram[start_of_ram_bank + address_requested];
+    }
+  }
+  printf("ERROR :: Attempted cartridge read from illegal address\n");
+  return 0x00;
+}
+
+void MBC1::write(u16 address, u8 value) {
+  if (0x0000 <= address && address <= 0x1FFF) {
+    if (value == 0x00) {
+      ramEnabled = false;
+    } else if (getLowNibble(value) == 0xA) {
+      ramEnabled = true;
+    }
+  } else if (0x2000 <= address && address <= 0x3FFF) {
+    value &= 0x1F; //discard top 3 bits
+    if (value == 0x00 || value == 0x20 || value == 0x40 || value == 0x60) {
+      romBank = value + 1;
+    } else {
+      romBank = value;
+    }
+  } else if (0x4000 <= address && address <= 0x5FFF) {
+    //TODO: Select Ram bank or upper bits of ROM bank number?
+  } else if (0x6000 <= address && address <= 0x7FFF) {
+    romBankingMode = value;
+  } else if (0xA000 <= address && address <= 0xBFFF) {
+    if (!ramEnabled) { return; }
+
+    u32 start_of_ram_bank = 0x2000 * ramBank;
+    u16 address_requested = address - 0xA000; //0x0000-0x1FFF
+    ram[start_of_ram_bank + address_requested] = value;
+  } else {
+    printf("ERROR :: Attempted cartridge read from illegal address\n");
+  }
+}
+
+
+
+
+
+
+
+
+
+// else if (0x2000 <= address && address <= 0x3FFF) {
+//   romBank = value == 0x00 ? 0x01 : value & 0x7F;
+// } else if (0x4000 <= address && address <= 0x5FFF) {
+//   if (value <= 0x03) {
+//     ram
+//   }
+// }
+
+// class MBC3: public Cartridge {
+// public:
+//   MBC3(u32 gameRomSize);
+
+//   u8 read(u16 address) override;
+//   void write(u16 address, u8 value) override;
+// private:
+//   u8* rom_bank;
+//   u8* ram_bank;
+//   bool ram_enabled = false;
+//   bool ram_over_rtc = true;
+//   bool rom_banking_mode = true;
+// };
+
+
+
+Cartridge* createCartridge(u8* rom, CartridgeInfo cartridgeInfo) {
+  switch (cartridgeInfo.type) {
+    case NONE:
+      return new NoMBC::NoMBC(rom, cartridgeInfo);
+    case MBC1: 
+      return new MBC1::MBC1(rom, cartridgeInfo);
+    case MBC3:
+      return new MBC3::MBC3(rom, cartridgeInfo);
+    default:
+      printf("ERROR :: Cartridge type not currently supported\nERROR :: Program will probably crash\n");
+      return new Cartridge(rom, cartridgeInfo);
+  }
 }

--- a/core/cartridge.hpp
+++ b/core/cartridge.hpp
@@ -12,11 +12,11 @@ const u16 ROM_BANK_SIZE = 32768; //32 kB
 const u16 RAM_BANK_SIZE = 8192; //8 bB
 
 enum MBCType {
-  NONE, //Tetris and Dr. Mario have no MBC at all
-  MBC1,
-  MBC2,
-  MBC3,
-  MBC5,
+  NO_MBC, //Tetris and Dr. Mario have no MBC at all
+  MBC_1,
+  MBC_2,
+  MBC_3,
+  MBC_5,
   OTHER,
 };
 
@@ -38,6 +38,7 @@ CartridgeInfo getInfo(u8* rom);
 class Cartridge {
 public:
   Cartridge(u8* rom, CartridgeInfo cartridgeInfo);
+  virtual ~Cartridge();
 
   virtual u8 read(u16 address);
   virtual void write(u16 address, u8 value);

--- a/core/cartridge.hpp
+++ b/core/cartridge.hpp
@@ -1,17 +1,92 @@
 #pragma once
 
+#include <string>
 #include "./util.hpp"
 
 const u16 BOOT_ROM_SIZE = 0x100;
-const u16 BANK_SIZE = 32768; //32 kB
+const u16 TITLE_ADDRESS = 0x134;
+const u16 MBC_TYPE_ADDRESS = 0x147;
+const u16 ROM_SIZE_ADDRESS = 0x148;
+const u16 RAM_SIZE_ADDRESS = 0x149;
+const u16 ROM_BANK_SIZE = 32768; //32 kB
+const u16 RAM_BANK_SIZE = 8192; //8 bB
+
+enum MBCType {
+  NONE, //Tetris and Dr. Mario have no MBC at all
+  MBC1,
+  MBC2,
+  MBC3,
+  MBC5,
+  OTHER,
+};
+
+MBCType getMBCType(u8 code);
+u32 getRomSize(u8 code);
+u32 getRamSize(u8 code);
+
+class CartridgeInfo { //lazy-man's struct
+public:
+  std::string title;
+
+  MBCType type;
+  u32 romSize;
+  u32 ramSize;
+};
+
+CartridgeInfo getInfo(u8* rom);
 
 class Cartridge {
 public:
-  Cartridge(u32 romSize);
-  ~Cartridge();
+  Cartridge(u8* rom, CartridgeInfo cartridgeInfo);
 
-  // public to facilitate rapid writes to mmu memory
-  u8* gameRom;
-  u8* bootRom;
-  u32 gameRomSize;
+  virtual u8 read(u16 address);
+  virtual void write(u16 address, u8 value);
+protected:
+  u8* rom;
+  u8* ram;
+
+  CartridgeInfo cartridgeInfo;
+};
+
+Cartridge* createCartridge(u8* rom, CartridgeInfo cartridgeInfo);
+
+
+
+class NoMBC: public Cartridge {
+public:
+  NoMBC(u8* rom, CartridgeInfo cartridgeInfo);
+
+  u8 read(u16 address) override;
+  void write(u16 address, u8 value) override;
+};
+
+
+
+class MBC1: public Cartridge {
+public:
+  MBC1(u8* rom, CartridgeInfo cartridgeInfo);
+
+  u8 read(u16 address) override;
+  void write(u16 address, u8 value) override;
+private:
+  u8 romBank = 0x01;
+  u8 ramBank = 0x00;
+  bool ramEnabled = false;
+  bool romBankingMode = true;
+};
+
+
+
+class MBC3: public Cartridge {
+public:
+  MBC3(u8* rom, CartridgeInfo cartridgeInfo);
+
+  u8 read(u16 address) override;
+  void write(u16 address, u8 value) override;
+private:
+  u8 romBank = 0x01;
+  u8 ramBank = 0x00;
+  bool ramEnabled = false;
+  bool ramOverRTC = true;
+  bool romBankingMode = true;
 };

--- a/core/cartridge.hpp
+++ b/core/cartridge.hpp
@@ -89,5 +89,6 @@ private:
   u8 ramBank = 0x00;
   bool ramEnabled = false;
   bool ramOverRTC = true;
+  u8 mappedRegister = 0x00;
   bool romBankingMode = true;
 };

--- a/core/mmu.cpp
+++ b/core/mmu.cpp
@@ -7,10 +7,8 @@ bool checkAddressIsValid(u16 address) {
     return address >= 0x0000 && address <= 0xffff;
 }
 
-MMU::MMU(Cartridge& cartridge, Input* input) : cartridge(cartridge), input(input) {
+MMU::MMU(Cartridge* cartridge, Input* input, u8* bootRom) : cartridge(cartridge), input(input), bootRom(bootRom) {
     memory = new u8[0x10000];
-    memcpy(memory, cartridge.gameRom, cartridge.gameRomSize);
-    memcpy(memory, cartridge.bootRom, BOOT_ROM_SIZE);
     memory[INPUT_ADDRESS] = 0xFF; // Input starts high, since high = unpressed
     memory[DIV_ADDRESS] = 0x00;
     memory[TIMA_ADDRESS] = 0x00;
@@ -75,14 +73,8 @@ void MMU::write(u16 address, u8 value) {
         input->writeInput(value);
     } else if (address == DIV_ADDRESS) {
         memory[address] = 0;
-    } else if (address == ENABLE_BOOT_ROM) {
-        if (value != 0) { 
-            // Re-map the cartridge
-            memcpy(memory, cartridge.gameRom, BOOT_ROM_SIZE);
-        } else {
-            // Probably not necessary, but it took me 5 seconds to write
-            memcpy(memory, cartridge.bootRom, BOOT_ROM_SIZE);
-        }
+    } else if (address == DISABLE_BOOT_ROM) {
+        bootRomDisabled = value; //non-zero disables 
         memory[address] = value;
     } else if (address == SB_ADDRESS) { //Serial port used for debugging
         memory[address] = value;

--- a/core/mmu.hpp
+++ b/core/mmu.hpp
@@ -9,7 +9,7 @@ const u16 DIV_ADDRESS = 0xFF04;
 const u16 TIMA_ADDRESS = 0xFF05;
 const u16 TMA_ADDRESS = 0xFF06;
 const u16 TAC_ADDRESS = 0xFF07;
-const u16 ENABLE_BOOT_ROM = 0xFF50;
+const u16 DISABLE_BOOT_ROM = 0xFF50;
 const u16 IF_ADDRESS = 0xFF0F;
 const u16 IE_ADDRESS = 0xFFFF;
 const u16 SB_ADDRESS = 0xFF01;
@@ -19,7 +19,7 @@ const u16 DMA_TRSFR_ADDRESS = 0xFF46;
 
 class MMU {
 public: 
-  MMU(Cartridge& cartridge, Input* input);
+  MMU(Cartridge* cartridge, Input* input, u8* bootRom);
   ~MMU();
 
   u8 read(u16 address);
@@ -31,9 +31,12 @@ public:
 
   bool blockedByPPU(u16 address);
 private:
-  Cartridge cartridge;
+  Cartridge* cartridge;
   Input* input; 
   // Array of size 0x10000 (Addresses 0x0 - 0xFFFF)
   // Some access rules: https://gbdev.io/pandocs/Memory_Map.html
   u8* memory; 
+
+  u8* bootRom;
+  bool bootRomDisabled = false;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
 
 	atexit(free_boot_rom);
 
-	u32 game_rom_size = load_binary_file(game_rom_filename, &game_rom);
+	load_binary_file(game_rom_filename, &game_rom);
 	
 	atexit(free_game_rom);
 

--- a/main.cpp
+++ b/main.cpp
@@ -137,11 +137,10 @@ int main(int argc, char *argv[]) {
 
 	u8 pixels[NUM_BYTES_OF_PIXELS] = {};
 
-	Cartridge cartridge = Cartridge(game_rom_size);
-	memcpy(cartridge.gameRom, game_rom, game_rom_size);
-	memcpy(cartridge.bootRom, boot_rom, BOOT_ROM_SIZE);
+	CartridgeInfo info = getInfo(game_rom);
+	Cartridge* cartridge = createCartridge(game_rom, info);
 	Input* input = new Input();
-	MMU mmu = MMU(cartridge, input);
+	MMU mmu = MMU(cartridge, input, boot_rom);
 	CPU cpu = CPU(mmu);
 	Timer timer = Timer(mmu, cpu);
 	PPU ppu = PPU(mmu, cpu);


### PR DESCRIPTION
Cartridges with memory banking now work, like Pokemon and Super Mario. We still need to implement on-cartridge saves like Pokemon does, probably just by writing to a file, then optionally reading it on cartridge creation.